### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ The [datamodel](https://github.com/Djimovanberlo/soaring-flocks-client/blob/mast
 
 ## Backend repository
 
-The backend of this project was built using Apollo server and Sequelize with postgres database. [click here to view backend repo](google.com).
+The backend of this project was built using Apollo server and Sequelize with postgres database. [click here to view backend repo](https://github.com/Djimovanberlo/soaring-flocks-server/tree/master).
 
 Thanks to Jan Gunster for drawing avatars.

--- a/src/pages/ActiveGame/PublicChat/MessageBox.js
+++ b/src/pages/ActiveGame/PublicChat/MessageBox.js
@@ -17,7 +17,7 @@ export default function MessageBox(props) {
     if (loading === false && data) {
       set_allQueriedMessages([...allQueriedMessages, data.messageAdded]);
     }
-  }, [loading, data]);
+  }, [loading, data, allQueriedMessages]);
 
   if (loading)
     return (

--- a/src/pages/ActiveGame/PublicChat/MessageBox.js
+++ b/src/pages/ActiveGame/PublicChat/MessageBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Alert, Card } from "react-bootstrap";
 import { useSubscription } from "@apollo/react-hooks";
 
@@ -8,16 +8,28 @@ export default function MessageBox(props) {
   const [allQueriedMessages, set_allQueriedMessages] = useState(
     props.allPublicMessages
   );
+
   const { data, error, loading } = useSubscription(SUB_ALL_PUBLIC_MESSAGES, {
     variables: {
       gameId: 1,
     },
   });
+
+  // adding subscribed messages to queried(props) had to be done through useCallback, to avoid infinite rerender.
+  const addMessage = useCallback(() => {
+    if (loading === false && data) {
+      set_allQueriedMessages((allQueriedMessages) => [
+        ...allQueriedMessages,
+        data.messageAdded,
+      ]);
+    }
+  }, [data, loading]);
+
   useEffect(() => {
     if (loading === false && data) {
-      set_allQueriedMessages([...allQueriedMessages, data.messageAdded]);
+      addMessage();
     }
-  }, [loading, data, allQueriedMessages]);
+  }, [loading, data, addMessage]);
 
   if (loading)
     return (

--- a/src/pages/ActiveGame/index.js
+++ b/src/pages/ActiveGame/index.js
@@ -37,13 +37,13 @@ export default function ActiveGame() {
     if (!token || player === {} || error_player) {
       history.push("/login");
     }
-  }, [token, player, error_player]);
+  }, [token, player, error_player, history]);
 
   useEffect(() => {
     if (loading_player === false && data_player) {
       dispatch(loginSuccess(data_player.getPlayerByToken));
     }
-  }, [loading_player, data_player]);
+  }, [loading_player, data_player, dispatch]);
 
   const {
     data: data_game,
@@ -63,7 +63,7 @@ export default function ActiveGame() {
         })
       );
     }
-  }, [loading_game, data_game]);
+  }, [loading_game, data_game, dispatch]);
 
   if (loading_game || loading_player) return "Loading...";
   if (error_game)


### PR DESCRIPTION
fixed chat rerender.
useEffect was used to add a new (subscribed) message to the queried messages. This useEffect required the array of messages in its dependancy-array. This would cause infinite rerender however.
This seems to be fixed by setting the message array inside useCallback, which is then called inside the useEffect.